### PR TITLE
feat: add webhook fallback endpoint for signature verification

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(make:*)",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(git commit:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,39 +1,10 @@
 {
   "permissions": {
     "allow": [
-      "Bash(mkdir:*)",
-      "Bash(go test:*)",
-      "Bash(go build:*)",
-      "mcp__ide__getDiagnostics",
-      "Bash(find:*)",
-      "Bash(make test:*)",
-      "Bash(docker-compose build:*)",
-      "Bash(docker-compose:*)",
       "Bash(make:*)",
-      "Bash(mv:*)",
-      "Bash(go mod:*)",
-      "Bash(go generate:*)",
-      "Bash(go install:*)",
-      "Bash(go fmt:*)",
-      "WebFetch(domain:developers.clicksign.com)",
-      "WebFetch(domain:developers.clicksign.com)",
-      "WebFetch(domain:developers.clicksign.com)",
-      "Bash(ls:*)",
-      "Bash(grep:*)",
-      "Bash(mockgen:*)",
-      "Bash(rm:*)",
-      "Bash(go vet:*)",
-      "WebFetch(domain:raw.githubusercontent.com)",
-      "cd:*",
-      "go:*",
-      "Bash(cd:*)",
-      "Bash(go:*)",
-      "Bash(swag:*)",
-      "Bash(curl:*)",
-      "Bash(docker:*)",
-      "Bash(curl:*)",
-      "curl:*"
+      "Bash(git add:*)"
     ],
-    "deny": []
+    "deny": [],
+    "ask": []
   }
 }

--- a/src/usecase/envelope/usecase_envelope_events.go
+++ b/src/usecase/envelope/usecase_envelope_events.go
@@ -2,6 +2,7 @@ package envelope
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -26,6 +27,38 @@ func (u *UsecaseEnvelopeService) CheckEventsFromClicksignAPI(ctx context.Context
 		return nil, fmt.Errorf("envelope does not have clicksign_key")
 	}
 
+	// Verificar se envelope já foi processado completamente
+	if envelope.Status == "completed" || envelope.Status == "cancelled" {
+		u.logger.WithFields(logrus.Fields{
+			"envelope_id": envelopeID,
+			"status":      envelope.Status,
+		}).Info("Envelope already in final state, skipping event check")
+
+		return &dtos.WebhookProcessResponseDTO{
+			Success: true,
+			Message: fmt.Sprintf("Envelope is already in '%s' state, no events processed", envelope.Status),
+		}, nil
+	}
+
+	// Verificar se já existem webhooks de assinatura processados para este envelope
+	existingWebhooks, err := webhookUsecase.GetWebhooksByDocumentKey(envelope.ClicksignKey)
+	if err != nil {
+		u.logger.WithError(err).Warn("Failed to check existing webhooks, continuing with event check")
+	}
+
+	processedSignEvents := 0
+	for _, webhook := range existingWebhooks {
+		if webhook.EventName == "sign" && webhook.Status == "processed" {
+			processedSignEvents++
+		}
+	}
+
+	u.logger.WithFields(logrus.Fields{
+		"envelope_id":           envelopeID,
+		"existing_sign_events":  processedSignEvents,
+		"total_webhooks":        len(existingWebhooks),
+	}).Info("Found existing webhooks for envelope")
+
 	// Buscar eventos via API da Clicksign
 	eventsService := clicksign.NewEventsService(u.clicksignClient, u.logger)
 	signatureStatuses, err := eventsService.GetSignaturesStatus(ctx, envelope.ClicksignKey)
@@ -34,10 +67,43 @@ func (u *UsecaseEnvelopeService) CheckEventsFromClicksignAPI(ctx context.Context
 	}
 
 	processedEvents := 0
+	skippedEvents := 0
+
+	// Criar mapa de signers já processados via webhook
+	processedSigners := make(map[string]bool)
+	for _, webhook := range existingWebhooks {
+		if webhook.EventName == "sign" && webhook.Status == "processed" {
+			// Tentar extrair signer_key do raw payload
+			var payloadData map[string]interface{}
+			if err := json.Unmarshal([]byte(webhook.RawPayload), &payloadData); err == nil {
+				if eventData, ok := payloadData["event"].(map[string]interface{}); ok {
+					if data, ok := eventData["data"].(map[string]interface{}); ok {
+						if signer, ok := data["signer"].(map[string]interface{}); ok {
+							if signerKey, ok := signer["key"].(string); ok {
+								processedSigners[signerKey] = true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	u.logger.WithField("processed_signers_count", len(processedSigners)).Info("Mapped already processed signers")
 
 	// Processar eventos de assinatura encontrados
 	for signerKey, status := range signatureStatuses {
 		if status.Signed && status.SignedAt != nil {
+			// Verificar se esta assinatura já foi processada via webhook
+			if processedSigners[signerKey] {
+				skippedEvents++
+				u.logger.WithFields(logrus.Fields{
+					"signer_key": signerKey,
+					"email":      status.Email,
+					"signed_at":  status.SignedAt,
+				}).Info("Skipping already processed signature event")
+				continue
+			}
 			// Criar webhook DTO simulando evento de assinatura
 			webhookDTO := &dtos.WebhookRequestDTO{
 				Event: dtos.WebhookEventDTO{
@@ -83,8 +149,30 @@ func (u *UsecaseEnvelopeService) CheckEventsFromClicksignAPI(ctx context.Context
 		}
 	}
 
+	// Montar mensagem de resposta detalhada
+	message := fmt.Sprintf("Checked Clicksign events API: processed %d new sign events", processedEvents)
+
+	if skippedEvents > 0 {
+		message += fmt.Sprintf(", skipped %d already processed events", skippedEvents)
+	}
+
+	if processedEvents > 0 {
+		message += ". Internal webhooks were triggered for new signatures"
+	}
+
+	if processedEvents == 0 && skippedEvents == 0 {
+		message += ". No signature events found in API"
+	}
+
+	u.logger.WithFields(logrus.Fields{
+		"envelope_id":      envelopeID,
+		"processed_events": processedEvents,
+		"skipped_events":   skippedEvents,
+		"total_api_events": len(signatureStatuses),
+	}).Info("Event check completed")
+
 	return &dtos.WebhookProcessResponseDTO{
 		Success: true,
-		Message: fmt.Sprintf("Checked Clicksign events API and processed %d sign events. Internal webhooks were triggered for each signature found.", processedEvents),
+		Message: message,
 	}, nil
 }

--- a/src/usecase/envelope/usecase_envelope_events.go
+++ b/src/usecase/envelope/usecase_envelope_events.go
@@ -1,0 +1,90 @@
+package envelope
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"app/api/handlers/dtos"
+	"app/infrastructure/clicksign"
+	"app/usecase/webhook"
+
+	"github.com/sirupsen/logrus"
+)
+
+// CheckEventsFromClicksignAPI verifica eventos da API da Clicksign e dispara webhooks internos
+func (u *UsecaseEnvelopeService) CheckEventsFromClicksignAPI(ctx context.Context, envelopeID int, webhookUsecase webhook.UsecaseWebhookInterface) (*dtos.WebhookProcessResponseDTO, error) {
+	u.logger.WithField("envelope_id", envelopeID).Info("Checking events from Clicksign API as webhook fallback")
+
+	// Buscar envelope
+	envelope, err := u.repositoryEnvelope.GetByID(envelopeID)
+	if err != nil {
+		return nil, fmt.Errorf("envelope not found: %w", err)
+	}
+
+	if envelope.ClicksignKey == "" {
+		return nil, fmt.Errorf("envelope does not have clicksign_key")
+	}
+
+	// Buscar eventos via API da Clicksign
+	eventsService := clicksign.NewEventsService(u.clicksignClient, u.logger)
+	signatureStatuses, err := eventsService.GetSignaturesStatus(ctx, envelope.ClicksignKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get events from Clicksign API: %w", err)
+	}
+
+	processedEvents := 0
+
+	// Processar eventos de assinatura encontrados
+	for signerKey, status := range signatureStatuses {
+		if status.Signed && status.SignedAt != nil {
+			// Criar webhook DTO simulando evento de assinatura
+			webhookDTO := &dtos.WebhookRequestDTO{
+				Event: dtos.WebhookEventDTO{
+					Name:       "sign",
+					OccurredAt: status.SignedAt.Format(time.RFC3339),
+					Data: map[string]interface{}{
+						"signer": map[string]interface{}{
+							"key":   signerKey,
+							"email": status.Email,
+							"name":  status.Name,
+						},
+					},
+				},
+				Document: dtos.WebhookDocumentDTO{
+					Key:        envelope.ClicksignKey,
+					AccountKey: "api-fallback", // Identificar como fallback manual
+					Status:     "running",
+				},
+			}
+
+			// Disparar o processamento de webhook existente
+			rawPayload := fmt.Sprintf(`{"source":"api_fallback","signer_key":"%s","envelope_id":%d,"signed_at":"%s"}`,
+				signerKey, envelopeID, status.SignedAt.Format(time.RFC3339))
+
+			_, err := webhookUsecase.ProcessWebhook(webhookDTO, rawPayload)
+			if err != nil {
+				u.logger.WithError(err).WithFields(logrus.Fields{
+					"signer_key":  signerKey,
+					"envelope_id": envelopeID,
+				}).Error("Failed to process sign event via internal webhook")
+				continue
+			}
+
+			processedEvents++
+
+			u.logger.WithFields(logrus.Fields{
+				"signer_key":  signerKey,
+				"envelope_id": envelopeID,
+				"signed_at":   status.SignedAt,
+				"email":       status.Email,
+				"name":        status.Name,
+			}).Info("Processed sign event via API fallback - webhook triggered internally")
+		}
+	}
+
+	return &dtos.WebhookProcessResponseDTO{
+		Success: true,
+		Message: fmt.Sprintf("Checked Clicksign events API and processed %d sign events. Internal webhooks were triggered for each signature found.", processedEvents),
+	}, nil
+}

--- a/src/usecase/envelope/usecase_envelope_interface.go
+++ b/src/usecase/envelope/usecase_envelope_interface.go
@@ -1,7 +1,9 @@
 package envelope
 
 import (
+	"app/api/handlers/dtos"
 	"app/entity"
+	"app/usecase/webhook"
 	"context"
 )
 
@@ -30,4 +32,5 @@ type IUsecaseEnvelope interface {
 	DeleteEnvelope(id int) error
 	ActivateEnvelope(id int) (*entity.EntityEnvelope, error)
 	NotifyEnvelope(ctx context.Context, envelopeID int, message string) error
+	CheckEventsFromClicksignAPI(ctx context.Context, envelopeID int, webhookUsecase webhook.UsecaseWebhookInterface) (*dtos.WebhookProcessResponseDTO, error)
 }


### PR DESCRIPTION
Implements manual fallback endpoint POST /envelopes/{id}/events/check that:
- Queries Clicksign events API when webhooks fail
- Processes signature events and triggers internal webhooks
- Maintains existing workflow using ProcessSignEvent
- Follows clean architecture with usecase layer separation

⏺ ✅ Implementação Completa com Verificações de Segurança!

  🛡️ Verificações Adicionadas:

  1. Verificação de Status do Envelope

  if envelope.Status == "completed" || envelope.Status == "cancelled" {
      return "Envelope is already in 'completed/cancelled' state, no events processed"
  }

  2. Verificação de Webhooks Já Processados

  existingWebhooks, err := webhookUsecase.GetWebhooksByDocumentKey(envelope.ClicksignKey)
  - Busca todos os webhooks já processados para o envelope
  - Extrai signer_key de webhooks sign com status processed

  3. Prevenção de Duplicação

  if processedSigners[signerKey] {
      skippedEvents++
      log.Info("Skipping already processed signature event")
      continue
  }

  📊 Cenários de Uso:

  Cenário 1: Envelope já completo

  POST /api/v1/envelopes/199/events/check
  Resposta:
  {
    "success": true,
    "message": "Envelope is already in 'completed' state, no events processed"
  }

  Cenário 2: Alguns webhooks já funcionaram

  POST /api/v1/envelopes/199/events/check
  Resposta:
  {
    "success": true,
    "message": "Checked Clicksign events API: processed 1 new sign events, skipped 2 already processed 
  events. Internal webhooks were triggered for new signatures"
  }

  Cenário 3: Nenhum webhook funcionou

  POST /api/v1/envelopes/199/events/check
  Resposta:
  {
    "success": true,
    "message": "Checked Clicksign events API: processed 3 new sign events. Internal webhooks were 
  triggered for new signatures"
  }

  Cenário 4: Todos já processados

  POST /api/v1/envelopes/199/events/check
  Resposta:
  {
    "success": true,
    "message": "Checked Clicksign events API: processed 0 new sign events, skipped 3 already processed 
  events"
  }

  🔍 Fluxo Completo com Verificações:

  1. ✅ Valida envelope existe
  2. ✅ Verifica se envelope tem clicksign_key
  3. 🆕 Verifica se envelope já está completo/cancelado
  4. 🆕 Busca webhooks já processados
  5. 🆕 Mapeia signatários já processados
  6. ✅ Consulta API de eventos da Clicksign
  7. 🆕 Para cada evento, verifica se já foi processado
  8. 🆕 Pula eventos duplicados
  9. ✅ Processa apenas eventos novos
  10. 🆕 Retorna estatísticas detalhadas

  📈 Logs Detalhados:

  INFO: Found existing webhooks for envelope (existing_sign_events=2, total_webhooks=5)
  INFO: Mapped already processed signers (processed_signers_count=2) 
  INFO: Skipping already processed signature event (signer_key=abc123)
  INFO: Processed sign event via API fallback (signer_key=def456)
  INFO: Event check completed (processed_events=1, skipped_events=2, total_api_events=3)