### PR TITLE
feat: adicionar campo de documentação nos DTOs e validação correspond…

### DIFF
--- a/src/api/handlers/dtos/envelope_dto.go
+++ b/src/api/handlers/dtos/envelope_dto.go
@@ -34,6 +34,7 @@ type EnvelopeSignatoryRequest struct {
 	Name              string                         `json:"name" binding:"required,min=2,max=255"`
 	Email             string                         `json:"email" binding:"required,email"`
 	Birthday          *string                        `json:"birthday,omitempty"`
+	Documentation     *string                        `json:"documentation,omitempty"`
 	PhoneNumber       *string                        `json:"phone_number,omitempty"`
 	HasDocumentation  *bool                          `json:"has_documentation,omitempty"`
 	Refusable         *bool                          `json:"refusable,omitempty"`
@@ -57,6 +58,7 @@ func (esr *EnvelopeSignatoryRequest) ToSignatoryCreateRequestDTO(envelopeID int)
 		Email:             esr.Email,
 		EnvelopeID:        envelopeID,
 		Birthday:          esr.Birthday,
+		Documentation:     esr.Documentation,
 		PhoneNumber:       esr.PhoneNumber,
 		HasDocumentation:  esr.HasDocumentation,
 		Refusable:         esr.Refusable,

--- a/src/api/handlers/dtos/signatory_dto.go
+++ b/src/api/handlers/dtos/signatory_dto.go
@@ -14,6 +14,7 @@ type SignatoryCreateRequestDTO struct {
 	Email             string                         `json:"email" binding:"required,email"`
 	EnvelopeID        int                            `json:"envelope_id" binding:"required"`
 	Birthday          *string                        `json:"birthday,omitempty"`
+	Documentation     *string                        `json:"documentation,omitempty"`
 	PhoneNumber       *string                        `json:"phone_number,omitempty"`
 	HasDocumentation  *bool                          `json:"has_documentation,omitempty"`
 	Refusable         *bool                          `json:"refusable,omitempty"`
@@ -53,6 +54,16 @@ func (dto *SignatoryCreateRequestDTO) Validate() error {
 		phoneRegex := regexp.MustCompile(`^\+\d{8,15}$`)
 		if !phoneRegex.MatchString(*dto.PhoneNumber) {
 			return fmt.Errorf("phone number must be in international format (+xxxxxxxx), got: %s", *dto.PhoneNumber)
+		}
+	}
+
+	// Validar documentation se fornecido
+	if dto.Documentation != nil && *dto.Documentation != "" {
+		docRegex := regexp.MustCompile(`[^\d]`)
+		cleanDoc := docRegex.ReplaceAllString(*dto.Documentation, "")
+
+		if len(cleanDoc) != 11 && len(cleanDoc) != 14 {
+			return fmt.Errorf("documentation must be a valid CPF (11 digits) or CNPJ (14 digits), got: %s", *dto.Documentation)
 		}
 	}
 
@@ -106,6 +117,7 @@ func (dto *SignatoryCreateRequestDTO) ToEntity() entity.EntitySignatory {
 		Email:             dto.Email,
 		EnvelopeID:        dto.EnvelopeID,
 		Birthday:          dto.Birthday,
+		Documentation:     dto.Documentation,
 		PhoneNumber:       dto.PhoneNumber,
 		HasDocumentation:  dto.HasDocumentation,
 		Refusable:         dto.Refusable,
@@ -120,6 +132,7 @@ type SignatoryUpdateRequestDTO struct {
 	Email             *string                        `json:"email,omitempty" binding:"omitempty,email"`
 	EnvelopeID        *int                           `json:"envelope_id,omitempty"`
 	Birthday          *string                        `json:"birthday,omitempty"`
+	Documentation     *string                        `json:"documentation,omitempty"`
 	PhoneNumber       *string                        `json:"phone_number,omitempty"`
 	HasDocumentation  *bool                          `json:"has_documentation,omitempty"`
 	Refusable         *bool                          `json:"refusable,omitempty"`
@@ -154,6 +167,16 @@ func (dto *SignatoryUpdateRequestDTO) Validate() error {
 		phoneRegex := regexp.MustCompile(`^\+\d{8,15}$`)
 		if !phoneRegex.MatchString(*dto.PhoneNumber) {
 			return fmt.Errorf("phone number must be in international format (+xxxxxxxx), got: %s", *dto.PhoneNumber)
+		}
+	}
+
+	// Validar documentation se fornecido
+	if dto.Documentation != nil && *dto.Documentation != "" {
+		docRegex := regexp.MustCompile(`[^\d]`)
+		cleanDoc := docRegex.ReplaceAllString(*dto.Documentation, "")
+
+		if len(cleanDoc) != 11 && len(cleanDoc) != 14 {
+			return fmt.Errorf("documentation must be a valid CPF (11 digits) or CNPJ (14 digits), got: %s", *dto.Documentation)
 		}
 	}
 
@@ -196,6 +219,9 @@ func (dto *SignatoryUpdateRequestDTO) ApplyToEntity(signatory *entity.EntitySign
 	if dto.Birthday != nil {
 		signatory.Birthday = dto.Birthday
 	}
+	if dto.Documentation != nil {
+		signatory.Documentation = dto.Documentation
+	}
 	if dto.PhoneNumber != nil {
 		signatory.PhoneNumber = dto.PhoneNumber
 	}
@@ -226,6 +252,7 @@ type SignatoryResponseDTO struct {
 	EnvelopeID        int                            `json:"envelope_id"`
 	ClicksignKey      string                         `json:"clicksign_key,omitempty"`
 	Birthday          *string                        `json:"birthday,omitempty"`
+	Documentation     *string                        `json:"documentation,omitempty"`
 	PhoneNumber       *string                        `json:"phone_number,omitempty"`
 	HasDocumentation  *bool                          `json:"has_documentation,omitempty"`
 	Refusable         *bool                          `json:"refusable,omitempty"`
@@ -243,6 +270,7 @@ func (dto *SignatoryResponseDTO) FromEntity(signatory *entity.EntitySignatory) {
 	dto.EnvelopeID = signatory.EnvelopeID
 	dto.ClicksignKey = signatory.ClicksignKey
 	dto.Birthday = signatory.Birthday
+	dto.Documentation = signatory.Documentation
 	dto.PhoneNumber = signatory.PhoneNumber
 	dto.HasDocumentation = signatory.HasDocumentation
 	dto.Refusable = signatory.Refusable

--- a/src/infrastructure/clicksign/dto/envelope_dto.go
+++ b/src/infrastructure/clicksign/dto/envelope_dto.go
@@ -199,6 +199,7 @@ type SignerCreateAttributes struct {
 	Name              string                   `json:"name"`
 	Email             string                   `json:"email"`
 	Birthday          string                   `json:"birthday,omitempty"`
+	Documentation     *string                  `json:"documentation,omitempty"`
 	PhoneNumber       *string                  `json:"phone_number,omitempty"`
 	HasDocumentation  bool                     `json:"has_documentation"`
 	Refusable         bool                     `json:"refusable"`

--- a/src/infrastructure/clicksign/signatory_mapper.go
+++ b/src/infrastructure/clicksign/signatory_mapper.go
@@ -32,6 +32,10 @@ func (m *SignatoryMapper) ToClicksignCreateRequest(signatory *entity.EntitySigna
 		attributes.Birthday = *signatory.Birthday
 	}
 
+	if signatory.Documentation != nil && *signatory.Documentation != "" {
+		attributes.Documentation = signatory.Documentation
+	}
+
 	if signatory.PhoneNumber != nil {
 		attributes.PhoneNumber = signatory.PhoneNumber
 	}

--- a/src/infrastructure/clicksign/signer_service.go
+++ b/src/infrastructure/clicksign/signer_service.go
@@ -73,6 +73,7 @@ func (s *SignerService) mapSignerDataToCreateRequest(signerData SignerData) *dto
 				Name:             signerData.Name,
 				Email:            signerData.Email,
 				Birthday:         signerData.Birthday,
+				Documentation:    signerData.Documentation,
 				PhoneNumber:      signerData.PhoneNumber,
 				HasDocumentation: signerData.HasDocumentation,
 				Refusable:        signerData.Refusable,
@@ -98,6 +99,7 @@ type SignerData struct {
 	Name              string
 	Email             string
 	Birthday          string
+	Documentation     *string
 	PhoneNumber       *string
 	HasDocumentation  bool
 	Refusable         bool

--- a/src/usecase/signatory/usecase_signatory_service.go
+++ b/src/usecase/signatory/usecase_signatory_service.go
@@ -84,6 +84,7 @@ func (u *UsecaseSignatoryService) CreateSignatory(signatory *entity.EntitySignat
 		Name:             clicksignRequest.Data.Attributes.Name,
 		Email:            clicksignRequest.Data.Attributes.Email,
 		Birthday:         clicksignRequest.Data.Attributes.Birthday,
+		Documentation:    clicksignRequest.Data.Attributes.Documentation,
 		PhoneNumber:      clicksignRequest.Data.Attributes.PhoneNumber,
 		HasDocumentation: clicksignRequest.Data.Attributes.HasDocumentation,
 		Refusable:        clicksignRequest.Data.Attributes.Refusable,


### PR DESCRIPTION
…ente

- Adicionado o campo `Documentation` em `EnvelopeSignatoryRequest`, `SignatoryCreateRequestDTO`, `SignatoryUpdateRequestDTO`, `SignatoryResponseDTO` e `EntitySignatory`.
- Implementada a validação para o campo `Documentation` para garantir que seja um CPF (11 dígitos) ou CNPJ (14 dígitos).
- Atualizados os mapeamentos e serviços relacionados para incluir o novo campo de documentação.